### PR TITLE
lsxfel command

### DIFF
--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -100,7 +100,7 @@ def main(argv=None):
         basename = os.path.basename(os.path.abspath(path))
 
         if os.path.isdir(path):
-            contents = os.listdir(path)
+            contents = sorted(os.listdir(path))
             if any(f.endswith('.h5') for f in contents):
                 # Run directory
                 describe_run(path)

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -67,6 +67,14 @@ def describe_file(path):
             print("  - ", dev)
         print()
 
+def describe_run(path):
+    basename = os.path.basename(path)
+    print(basename, ": Run directory")
+    print()
+
+    run = RunHandler(path)
+    run.info()
+
 def main(argv=None):
     ap = argparse.ArgumentParser(prog='lsxfel',
         description="Summarise XFEL data in files or folders")
@@ -78,6 +86,9 @@ def main(argv=None):
         path = paths[0]
         if os.path.isdir(path):
             contents = os.listdir(path)
+            if any(f.endswith('.h5') for f in contents):
+                # Run directory
+                describe_run(path)
         elif os.path.isfile(path):
             if path.endswith('.h5'):
                 describe_file(path)

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import re
+import sys
 
 from .reader import H5File, RunHandler
 
@@ -31,7 +32,29 @@ def describe_file(path):
     print(basename, ":", file_descr)
 
     h5file = H5File(path)
+    print(len(h5file.train_ids), "trains")
+    print()
 
+    if is_detector:
+        pass
+    else:
+        ctrl, inst = set(), set()
+        for src in h5file.sources:
+            srcparts = src.split('/')
+            if srcparts[0] == 'CONTROL':
+                ctrl.add('/'.join(srcparts[1:4]))
+            elif srcparts[0] == 'INSTRUMENT':
+                inst.add('/'.join(srcparts[1:4]))
+
+        print(len(ctrl), "control devices")
+        for dev in sorted(ctrl):
+            print("  - ", dev)
+        print()
+
+        print(len(inst), "instrument devices")
+        for dev in sorted(inst):
+            print("  - ", dev)
+        print()
 
 def main(argv=None):
     ap = argparse.ArgumentParser(prog='lsxfel',
@@ -44,13 +67,17 @@ def main(argv=None):
         path = paths[0]
         if os.path.isdir(path):
             contents = os.listdir(path)
-        elif path.endswith('.h5'):
-            describe_file(path)
+        elif os.path.isfile(path):
+            if path.endswith('.h5'):
+                describe_file(path)
+            else:
+                print(os.path.basename(path), ": Unrecognised file")
+                return 2
         else:
-            print(os.path.basename(path), ": Unrecognised file")
-            return 1
+            print(path, ': File/folder not found')
+            return 2
     else:
         print("TODO: Multiple files/folders")
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -45,13 +45,13 @@ def describe_file(path):
             elif srcparts[0] == 'INSTRUMENT':
                 inst.add('/'.join(srcparts[1:4]))
 
-        print(len(ctrl), "control devices")
-        for dev in sorted(ctrl):
+        print(len(inst), "instrument devices")
+        for dev in sorted(inst):
             print("  - ", dev)
         print()
 
-        print(len(inst), "instrument devices")
-        for dev in sorted(inst):
+        print(len(ctrl), "control devices")
+        for dev in sorted(ctrl):
             print("  - ", dev)
         print()
 

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -97,7 +97,7 @@ def main(argv=None):
 
     if len(paths) == 1:
         path = paths[0]
-        basename = os.path.basename(os.path.abspath(path))
+        basename = os.path.basename(os.path.abspath(path.rstrip('/')))
 
         if os.path.isdir(path):
             contents = sorted(os.listdir(path))

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -1,0 +1,56 @@
+"""Summarise XFEL data in files or folders
+"""
+import argparse
+import os
+import re
+
+from .reader import H5File, RunHandler
+
+rawcorr_descr = {'RAW': 'Raw', 'CORR': 'Corrected'}
+detector_names = {'AGIPD', 'LPD'}
+
+def describe_file(path):
+    """Describe a single HDF5 data file"""
+    basename = os.path.basename(path)
+    nameparts = basename[:-3].split('-')
+    assert len(nameparts) == 4, basename
+    rawcorr, runno, datasrc, segment = nameparts
+    m = re.match(r'([A-Z]+)(\d+)', datasrc)
+    is_detector = False
+    if m and m.group(1) == 'DA':
+        file_descr = "Aggregated data"
+    elif m and m.group(1) in detector_names:
+        is_detector = True
+        name, moduleno = m.groups()
+        file_descr = "{} detector data from {} module {}".format(
+            rawcorr_descr.get(rawcorr, '?'), name, moduleno
+        )
+    else:
+        file_descr = "Unknown data source ({})", datasrc
+
+    print(basename, ":", file_descr)
+
+    h5file = H5File(path)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog='lsxfel',
+        description="Summarise XFEL data in files or folders")
+    ap.add_argument('paths', nargs='*', help="Files/folders to look at")
+    args = ap.parse_args(argv)
+    paths = args.paths or [os.path.abspath(os.getcwd())]
+
+    if len(paths) == 1:
+        path = paths[0]
+        if os.path.isdir(path):
+            contents = os.listdir(path)
+        elif path.endswith('.h5'):
+            describe_file(path)
+        else:
+            print(os.path.basename(path), ": Unrecognised file")
+            return 1
+    else:
+        print("TODO: Multiple files/folders")
+
+if __name__ == '__main__':
+    main()

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -36,7 +36,18 @@ def describe_file(path):
     print()
 
     if is_detector:
-        pass
+        img_source = [src for src in h5file.sources
+                      if re.match(r'INSTRUMENT/.+/image', src)][0]
+        img_ds = h5file.file[img_source + '/data']
+        img_index_name = 'INDEX/' + img_source.split('/', 1)[1]
+        img_index_count = h5file.file[img_index_name + '/count']
+        # Some trains have 0 frames; max is the interesting value
+        frames_per_train = img_index_count[:].max()
+
+        print("{} × {}".format(*img_ds.shape[-2:]), "pixels")
+        print("{} frames per train, {} total".format(
+            frames_per_train, img_ds.shape[0]
+        ))
     else:
         ctrl, inst = set(), set()
         for src in h5file.sources:

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -3,6 +3,7 @@
 import argparse
 from enum import Enum
 import os
+import os.path as osp
 import re
 import sys
 
@@ -106,10 +107,18 @@ def main(argv=None):
                 describe_run(path)
             elif any(re.match(r'r\d+', f) for f in contents):
                 # Proposal directory, containing runs
-                print(basename, ": Proposal directory")
+                print(basename, ": Proposal data directory")
                 print()
                 for f in contents:
                     child_path = os.path.join(path, f)
+                    if re.match(r'r\d+', f) and os.path.isdir(child_path):
+                        summarise_run(child_path, indent='  ')
+            elif osp.isdir(osp.join(path, 'raw')):
+                print(basename, ": Proposal directory")
+                print()
+                print('{}/raw/'.format(basename))
+                for f in sorted(os.listdir(osp.join(path, 'raw'))):
+                    child_path = os.path.join(path, 'raw', f)
                     if re.match(r'r\d+', f) and os.path.isdir(child_path):
                         summarise_run(child_path, indent='  ')
             else:

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -109,7 +109,7 @@ def summarise_run(path, indent=''):
     for f in first_group:
         train_ids.update(H5File(osp.join(path, f)).train_ids)
 
-    print("{}{} : Run of {} trains, with {} detector files and {} others".format(
+    print("{}{} : Run of {:>4} trains, with {:>3} detector files and {:>3} others".format(
         indent, basename, len(train_ids), n_detector, n_other
     ))
 

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -31,14 +31,10 @@ def describe_file(path):
     print()
 
     if info.is_detector:
-        img_data, img_index = find_image(h5file)
-        # Some trains have 0 frames; max is the interesting value
-        frames_per_train = img_index['count'][:].max()
-        total_frames = img_index['count'][:].sum()
-
-        print("{} × {}".format(*img_data.shape[-2:]), "pixels")
+        detector_info = h5file.detector_info()
+        print("{} × {} pixels".format(*detector_info['dims']))
         print("{} frames per train, {} total".format(
-            frames_per_train, total_frames,
+            detector_info['frames_per_train'], detector_info['total_frames'],
         ))
     else:
         ctrl, inst = set(), set()
@@ -68,13 +64,9 @@ def summarise_file(path):
     ntrains = len(h5file.train_ids)
 
     if info.is_detector:
-        img_data, img_index = find_image(h5file)
-        # Some trains have 0 frames; max is the interesting value
-        frames_per_train = img_index['count'][:].max()
-        total_frames = img_index['count'][:].sum()
-
+        dinfo = h5file.detector_info()
         print("  {} trains, {} frames/train, {} total frames".format(
-            len(h5file.train_ids), frames_per_train, total_frames,
+            len(h5file.train_ids), dinfo['frames_per_train'], dinfo['total_frames']
         ))
     else:
         print("  {} trains, {} devices".format(

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -90,15 +90,15 @@ def count_trains(run_files, path):
     for f in sorted(run_files):
         m = re.match(r'(.+)-S\d+\.h5', osp.basename(f))
         if m:
-            segment_sequences[m.group(1)] = f
+            segment_sequences[m.group(1)].append(f)
 
     if len(segment_sequences) < 1:
         raise ValueError("No data files recognised in %s" % path)
 
     first_key, first_group = sorted(segment_sequences.items())[0]
     train_ids = set()
-    for path in first_group:
-        train_ids.update(H5File(path).train_ids)
+    for f in first_group:
+        train_ids.update(H5File(f).train_ids)
 
     return len(train_ids)
 

--- a/euxfel_h5tools/lsxfel.py
+++ b/euxfel_h5tools/lsxfel.py
@@ -6,32 +6,7 @@ import os
 import re
 import sys
 
-from .reader import H5File, RunHandler
-
-rawcorr_descr = {'RAW': 'Raw', 'CORR': 'Corrected'}
-detector_names = {'AGIPD', 'LPD'}
-
-
-class FileInfo:
-    is_detector = False
-
-    def __init__(self, basename):
-        self.basename = basename
-        nameparts = basename[:-3].split('-')
-        assert len(nameparts) == 4, basename
-        rawcorr, runno, datasrc, segment = nameparts
-        m = re.match(r'([A-Z]+)(\d+)', datasrc)
-
-        if m and m.group(1) == 'DA':
-            self.description = "Aggregated data"
-        elif m and m.group(1) in detector_names:
-            self.is_detector = True
-            name, moduleno = m.groups()
-            self.description = "{} detector data from {} module {}".format(
-                rawcorr_descr.get(rawcorr, '?'), name, moduleno
-            )
-        else:
-            self.description = "Unknown data source ({})", datasrc
+from .reader import H5File, RunHandler, FilenameInfo
 
 def find_image(h5file):
     """Find the image data in a detector file
@@ -48,7 +23,7 @@ def find_image(h5file):
 def describe_file(path):
     """Describe a single HDF5 data file"""
     basename = os.path.basename(path)
-    info = FileInfo(basename)
+    info = FilenameInfo(basename)
     print(basename, ":", info.description)
 
     h5file = H5File(path)
@@ -86,7 +61,7 @@ def describe_file(path):
 
 def summarise_file(path):
     basename = os.path.basename(path)
-    info = FileInfo(basename)
+    info = FilenameInfo(basename)
     print(basename, ":", info.description)
 
     h5file = H5File(path)

--- a/euxfel_h5tools/reader.py
+++ b/euxfel_h5tools/reader.py
@@ -267,6 +267,7 @@ class H5File:
 
         return {
             'dims': img_ds.shape[-2:],
+            # Some trains have 0 frames; max is the interesting value
             'frames_per_train': img_index['count'][:].max(),
             'total_frames': img_index['count'][:].sum(),
         }

--- a/euxfel_h5tools/reader.py
+++ b/euxfel_h5tools/reader.py
@@ -10,7 +10,7 @@ You should have received a copy of the 3-Clause BSD License along with this
 program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
-from contextlib import contextmanager
+from collections import defaultdict
 import datetime
 from glob import glob
 import h5py
@@ -27,6 +27,36 @@ __all__ = ['H5File', 'RunHandler', 'stack_data',
 RUN_DATA = 'RUN'
 INDEX_DATA = 'INDEX'
 METADATA = 'METADATA'
+
+DETECTOR_NAMES = {'AGIPD', 'LPD'}
+
+
+class FilenameInfo:
+    is_detector = False
+    detector_name = None
+    detector_moduleno = -1
+
+    _rawcorr_descr = {'RAW': 'Raw', 'CORR': 'Corrected'}
+
+    def __init__(self, path):
+        self.basename = osp.basename(path)
+        nameparts = self.basename[:-3].split('-')
+        assert len(nameparts) == 4, self.basename
+        rawcorr, runno, datasrc, segment = nameparts
+        m = re.match(r'([A-Z]+)(\d+)', datasrc)
+
+        if m and m.group(1) == 'DA':
+            self.description = "Aggregated data"
+        elif m and m.group(1) in DETECTOR_NAMES:
+            self.is_detector = True
+            name, moduleno = m.groups()
+            self.detector_name = name
+            self.detector_moduleno = moduleno
+            self.description = "{} detector data from {} module {}".format(
+                self._rawcorr_descr.get(rawcorr, '?'), name, moduleno
+            )
+        else:
+            self.description = "Unknown data source ({})", datasrc
 
 
 class H5File:
@@ -52,6 +82,7 @@ class H5File:
         If the provided path is not a valid HDF5 file.
     """
     def __init__(self, path, driver=None):
+        self.path = path
         if not h5py.is_hdf5(path):
             raise FileNotFoundError(path, 'is not a valid HDF5 file.')
         self.file = h5py.File(path, 'r', driver=driver)
@@ -220,6 +251,26 @@ class H5File:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def detector_info(self):
+        """Get statistics about the detector data.
+
+        Returns a dictionary with keys:
+        - 'dims' (pixel dimensions)
+        - 'frames_per_train'
+        - 'total_frames'
+        """
+
+        img_source = [src for src in self.sources
+                      if re.match(r'INSTRUMENT/.+/image', src)][0]
+        img_ds = self.file[img_source + '/data']
+        img_index = self.index[img_source.split('/', 1)[1]]
+
+        return {
+            'dims': img_ds.shape[-2:],
+            'frames_per_train': img_index['count'][:].max(),
+            'total_frames': img_index['count'][:].sum(),
+        }
+
 
 class RunHandler:
     """Handles a 'run' generated at the European XFEL.
@@ -360,21 +411,54 @@ class RunHandler:
         span_sec = (last_train - first_train) / 10
         span_txt = str(datetime.timedelta(seconds=span_sec))
 
+        detector_files, non_detector_files = [], []
+        detector_modules = defaultdict(list)
+        for f in self.files:
+            fni = FilenameInfo(f.path)
+            if fni.is_detector:
+                detector_files.append(f)
+                detector_modules[(fni.detector_name, fni.detector_moduleno)].append(f)
+            else:
+                non_detector_files.append(f)
+
+        # A run should only have one detector, but if that changes, don't hide it
+        detector_name = ','.join(sorted(set(k[0] for k in detector_modules)))
+
         # devices info
-        ctrl, inst = self._get_devices(self.files)
+        ctrl, inst = self._get_devices(non_detector_files)
 
         # disp
-        print('Run information')
-        print('\tDuration:      ', span_txt)
-        print('\tFirst train ID:', first_train)
-        print('\tLast train ID: ', last_train)
-        print('\t# of trains:   ', train_count)
+        print('# of trains:   ', train_count)
+        print('Duration:      ', span_txt)
+        print('First train ID:', first_train)
+        print('Last train ID: ', last_train)
         print()
-        print('Devices')
-        print('\tInstruments')
-        [print('\t-', d) for d in sorted(inst)] or print('\t-')
-        print('\tControls')
-        [print('\t-', d) for d in sorted(ctrl)] or print('\t-')
+
+        print("{} detector modules ({})".format(
+            len(detector_modules), detector_name
+        ))
+        if len(detector_modules) > 0:
+            # Show detail on the first module (the others should be similar)
+            mod_key = sorted(detector_modules)[0]
+            mod_files = detector_modules[mod_key]
+            dinfo = [f.detector_info() for f in mod_files]
+            print("  e.g. module {}{} : {} × {} pixels".format(
+                *mod_key, *dinfo[0]['dims'],
+            ))
+            print("  {} frames per train, {} total frames".format(
+                max(i['frames_per_train'] for i in dinfo),
+                sum(i['total_frames'] for i in dinfo),
+            ))
+        print()
+
+        print(len(inst), 'instrument devices (excluding detectors):')
+        for d in sorted(inst):
+            print('  -', d)
+        print()
+        print(len(ctrl), 'control devices:')
+        for d in sorted(ctrl):
+            print('  -', d)
+        print()
 
     def train_info(self, train_id):
         """Show information about a specific train in the run.

--- a/euxfel_h5tools/utils.py
+++ b/euxfel_h5tools/utils.py
@@ -10,7 +10,6 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 
 import fabio
 import h5py
-import matplotlib.pyplot as plot
 import numpy as np
 
 
@@ -95,6 +94,7 @@ class QuickView:
             self.display()
 
     def display(self, index=None):
+        import matplotlib.pyplot as plot
         if index is None:
             index = self._current_index
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,11 @@ setup(name="euxfel_h5tools",
       license="BSD-3-Clause",
       packages=find_packages(),
       scripts=["bin/euxfel_h5tool", "bin/euxfel_h5tool_tmp.py"],
+      entry_points={
+          "console_scripts": [
+              "lsxfel = euxfel_h5tools.lsxfel:main",
+          ],
+      },
       install_requires=[r for r in read('requirements.txt').splitlines()],
       classifiers=[
           'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This adds an `lsxfel` command, which can describe the available data in files, runs, or a proposal directory. For files and runs, it shows a brief summary when it's looking at several, or more details when it's looking at just one. I'll put some examples below.

I need to check some stuff about the data files within a run. Opening all the files to get shared metadata can be very slow, so I've tried to count train IDs by opening just the segments from one aggregator, but I don't know if that's reliable.

```
(h5tools) [kluyvert@max-exfl015]/gpfs/exfel/exp/SPB/201701/p002012% lsxfel 
p002012 : Proposal directory

p002012/raw/
  r0001 : Run of 13620 trains, with 168 detector files and  14 others
  r0003 : Run of 3000 trains, with 192 detector files and   0 others
  r0004 : Run of 3000 trains, with 192 detector files and   0 others
  r0005 : Run of 1000 trains, with  64 detector files and   0 others
  r0006 : Run of 1000 trains, with  64 detector files and   0 others
  r0007 : Run of 1500 trains, with  96 detector files and   0 others
  r0008 : Run of 2624 trains, with  96 detector files and   3 others
  r0009 : Run of 1500 trains, with  96 detector files and   0 others
  r0010 : Run of 1500 trains, with  96 detector files and   0 others
  r0011 : Run of 1500 trains, with  96 detector files and   0 others
  r0012 : Run of 1500 trains, with  96 detector files and   0 others
  r0014 : Run of 1183 trains, with  64 detector files and   2 others
  r0015 : Run of 6284 trains, with   0 detector files and   7 others
  r0019 : Run of 1450 trains, with  64 detector files and   2 others
  r0020 : Run of    0 trains, with  11 detector files and   1 others
  r0021 : Run of 1000 trains, with  64 detector files and   4 others
  r0022 : Run of 1427 trains, with  64 detector files and   2 others
  r0023 : Run of 1949 trains, with  64 detector files and   2 others
  r0024 : Run of 3685 trains, with 192 detector files and   4 others
...

(h5tools) [kluyvert@max-exfl015]/gpfs/exfel/exp/SPB/201701/p002012% lsxfel raw/r0348 
r0348 : Run directory

# of trains:    1983
Duration:       0:03:18.200000
First train ID: 78809934
Last train ID:  78811916

16 detector modules (AGIPD)
  e.g. module AGIPD00 : 512 × 128 pixels
  64 frames per train, 120448.0 total frames

3 instrument devices (excluding detectors):
  - SA1_XTD2_XGM/XGM/DOOCS:output
  - SPB_IRU_SIDEMIC_CAM:daqOutput/data
  - SPB_XTD9_XGM/XGM/DOOCS:output

13 control devices:
  - ACC_SYS_DOOCS/CTRL/BEAMCONDITIONS
  - SA1_XTD2_XGM/XGM/DOOCS
  - SPB_IRU_AGIPD1M/PSC/HV
  - SPB_IRU_AGIPD1M/TSENS/H1_T_EXTHOUS
  - SPB_IRU_AGIPD1M/TSENS/H2_T_EXTHOUS
  - SPB_IRU_AGIPD1M/TSENS/Q1_T_BLOCK
  - SPB_IRU_AGIPD1M/TSENS/Q2_T_BLOCK
  - SPB_IRU_AGIPD1M/TSENS/Q3_T_BLOCK
  - SPB_IRU_AGIPD1M/TSENS/Q4_T_BLOCK
  - SPB_IRU_AGIPD1M1/CTRL/MC1
  - SPB_IRU_AGIPD1M1/CTRL/MC2
  - SPB_IRU_VAC/GAUGE/GAUGE_FR_6
  - SPB_XTD9_XGM/XGM/DOOCS

(h5tools) [kluyvert@max-exfl015]/gpfs/exfel/exp/SPB/201701/p002012% lsxfel raw/r0348/RAW-R0348-DA01-S0000*
RAW-R0348-DA01-S00000.h5 : Aggregated data
  500 trains, 6 devices
RAW-R0348-DA01-S00001.h5 : Aggregated data
  500 trains, 6 devices
RAW-R0348-DA01-S00002.h5 : Aggregated data
  500 trains, 6 devices
RAW-R0348-DA01-S00003.h5 : Aggregated data
  481 trains, 6 devices

(h5tools) [kluyvert@max-exfl015]/gpfs/exfel/exp/SPB/201701/p002012% lsxfel raw/r0348/RAW-R0348-DA01-S00001.h5 
RAW-R0348-DA01-S00001.h5 : Aggregated data
500 trains

3 instrument devices
  -  SA1_XTD2_XGM/XGM/DOOCS:output
  -  SPB_IRU_SIDEMIC_CAM:daqOutput/data
  -  SPB_XTD9_XGM/XGM/DOOCS:output

3 control devices
  -  ACC_SYS_DOOCS/CTRL/BEAMCONDITIONS
  -  SA1_XTD2_XGM/XGM/DOOCS
  -  SPB_XTD9_XGM/XGM/DOOCS

(h5tools) [kluyvert@max-exfl015]/gpfs/exfel/exp/SPB/201701/p002012% lsxfel raw/r0348/RAW-R0348-AGIPD03-S00001.h5 
RAW-R0348-AGIPD03-S00001.h5 : Raw detector data from AGIPD module 03
512 trains

512 × 128 pixels
64 frames per train, 32768 total
```